### PR TITLE
Add basic baum head freedom field

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Other major features are:
 * [customizable **G-code macros**](https://github.com/prusa3d/PrusaSlicer/wiki/PrusaSlicer-Macro-Language) and output filename with variable placeholders
 * support for **post-processing scripts**
 * **cooling logic** controlling fan speed and dynamic print speed
+* Expertenmodus-Feld `baum_head_freedom` zur Beschreibung des Druckkopf-Freiheitsgrades (siehe [Dokumentation](doc/Freiheitsgrade_Baum.md))
 
 ### Development
 

--- a/doc/Freiheitsgrade_Baum.md
+++ b/doc/Freiheitsgrade_Baum.md
@@ -1,0 +1,11 @@
+# Freiheitsgrade bei Baum
+
+Das optionale Feld `baum_head_freedom` beschreibt im Expertenmodus die Geometrie des Druckkopfes. Werte werden in positiver und negativer Richtung der Achsen angegeben.
+
+Beispiel für Prusa Mini+:
+
+```
+baum_head_freedom = "y+=37,y-=13,x+=85,x-=32,z+=25,rot=12"
+```
+
+Diese Information kann genutzt werden, um spezielle Druckstrategien für Bauteile mit versetzten Säulen umzusetzen.

--- a/tests/data/default_fff.ini
+++ b/tests/data/default_fff.ini
@@ -52,6 +52,7 @@ extruder_clearance_height = 20
 extruder_clearance_radius = 45
 extruder_colour = ""
 extruder_offset = 0x0
+baum_head_freedom = ""
 extrusion_axis = E
 extrusion_multiplier = 1
 extrusion_width = 0.45


### PR DESCRIPTION
## Summary
- document new `baum_head_freedom` expert setting
- mention the setting in README
- add placeholder entry in test configuration

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68812f1d591c8331a67da190be950ca5